### PR TITLE
Moved cache related $skip_reason up

### DIFF
--- a/ubuntu-7.4/rootfs/etc/nginx/nginx.conf
+++ b/ubuntu-7.4/rootfs/etc/nginx/nginx.conf
@@ -31,12 +31,12 @@ events {
 }
 
 http {
-  
+
   # Configure hashmaps so that environment does not change defaults
   map_hash_max_size 262144;
   map_hash_bucket_size 128;
   server_names_hash_bucket_size 64;
-  
+
   # Hide nginx version information.
   server_tokens off;
 
@@ -121,6 +121,9 @@ http {
         # Init the cache mode variable
         set $cachemode "";
 
+        # Set default cache skip reason
+        set $skip_reason "";
+
         root ${WEB_ROOT};
 
         # Use index.php if it exists but also allow static websites in subfolders
@@ -134,14 +137,13 @@ http {
         disable_symlinks off;
 
         ## state variable must be set as it will crash nginx if logged in cache is not used
-        set $state '';        
+        set $state '';
 
         # Include custom nginx server additions from project
         include ${NGINX_INCLUDE_DIR}/server/*.conf;
         include ${NGINX_INCLUDE_DIR}/environments/${WP_ENV}/server/*.conf;
 
         set $custom_parameters "";
-        set $skip_reason "";
 
         # Include custom cache confs
         include ${NGINX_INCLUDE_DIR}/cache/*.conf;
@@ -349,7 +351,7 @@ http {
             include cache/fastcgicache.conf;
 
             #Enable project spesific config to root block
-            include ${NGINX_INCLUDE_DIR}/environments/${WP_ENV}/root/*.conf;             
+            include ${NGINX_INCLUDE_DIR}/environments/${WP_ENV}/root/*.conf;
 
             # Fallback into php
             include fastcgi_settings.conf;


### PR DESCRIPTION
Fixes `using uninitialized "skip_reason" variable while reading response header from upstream` error.

Cleaned some extra whitespace while at it.