### PR TITLE
Update fastcgicache_skip_rules.conf

### DIFF
--- a/ubuntu-7.4/rootfs/etc/nginx/cache/fastcgicache_skip_rules.conf
+++ b/ubuntu-7.4/rootfs/etc/nginx/cache/fastcgicache_skip_rules.conf
@@ -88,7 +88,13 @@ set_by_lua_block $cache_args {
         ngx.var.without = ngx.encode_args( without )
 
         -- Return accepted query var key-value pairs to be used in the cache key
-        return "?" .. table.concat( with, "&" )
+        local len = 0
+         
+        for k, v in pairs(with) do
+            len = len + 1
+        end
+        return len > 0 and "?" .. table.concat( with, "&" ) or ""
+
     else
         -- Get a list of blacklisted query vars from env variable
         local blacklist = split( ( os.getenv( 'NGINX_FASTCGI_CACHE_QUERYVARS' ) or "" ), "," )


### PR DESCRIPTION
? was added to cachekey even when no parameters are present. This will fix it.